### PR TITLE
homeflix systemd service file

### DIFF
--- a/homeflix.service
+++ b/homeflix.service
@@ -1,0 +1,13 @@
+[Unit]
+After=network.target
+
+[Service]
+Environment=NODE_PORT=3000
+Type=simple
+User=root
+ExecStart=/usr/bin/node /root/HomeFlix/bin/www
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
basic systemd service file that can be enabled using systemd to start homeflix as a daemon at boot.