### PR TITLE
windows powershell script to setup nodejs-arch

### DIFF
--- a/run-me.ps1
+++ b/run-me.ps1
@@ -1,0 +1,8 @@
+#Set-ExecutionPolicy Unrestricted <== run this command in powershell as admin in order to execute this ps1 script
+Get-Content Dockerfile | docker build -
+$homeflixmount = "/c/Users/$ENV:username/Videos/"
+Write-Host "place videos you want to watch in the $ENV:username/Videos/ directory"
+docker run -d -i -v $ENV:homeflixmount:/mnt/videos -p 3001:3000 --name=homeflix -t nodejs-arch:latest
+docker ps -a
+Write-Host "open your favorite internet browser use url: http://localhost:3001 to view homeflix"
+Write-Host "enjoy"


### PR DESCRIPTION
This is the windows variant of the bash script used to create nodejs-arch docker image for homeflix. It is up to you to get docker setup in windows using linux containers properly.... Im working on making the ability to recursively locate all folders that house videos on a machine and make many volume mounts to point into homeflix video folder in image (which will have subdirectories created reflecting names of video directories discovered from folder search) that will probably be next commit but only for linux because Windows is nothing but headaches and much loss in sanity. ....